### PR TITLE
Replace calls to Proc#bind (deprecated in Rails 4).

### DIFF
--- a/lib/fixjour/generator.rb
+++ b/lib/fixjour/generator.rb
@@ -10,7 +10,11 @@ module Fixjour
 
     def call(context, overrides={})
       overrides = OverridesHash.new(overrides)
-      result = block.bind(context).call(*args(overrides))
+      if context.respond_to?(:instance_exec)
+        result = context.instance_exec(*args(overrides), &block)
+      else
+        result = block.bind(context).call(*args(overrides))
+      end
       case result
       when Hash then klass.new(result.merge(overrides))
       else result


### PR DESCRIPTION
Rails 4 complains with the way `bind` is being used in Fixjour: `DEPRECATION WARNING: Proc#bind is deprecated and will be removed in future versions.`

I've changed it to use `instance_exec` if available, or `bind` otherwise.

Unfortunately, I couldn't get an old version of rspec working in my development environment in order to run the tests. I did a quick check and It Works For Me™ on both Rails 3 and Rails 4. But the tests should be run before merging of course. :)
